### PR TITLE
fix: lua/llm/tools/utils.lua: utils.overwrite_selection()

### DIFF
--- a/lua/llm/tools/utils.lua
+++ b/lua/llm/tools/utils.lua
@@ -53,6 +53,10 @@ function utils.overwrite_selection(context, contents)
     context.start_col = context.start_col - 1
   end
 
+  if context.end_col > 0 then
+    context.end_col = context.end_col - 1
+  end
+
   vim.api.nvim_buf_set_text(
     context.bufnr,
     context.start_line - 1,


### PR DESCRIPTION
decrease 1 step end_col to avoid triggering error: Invalid end_col: out of range

fixes issue: #108 

![llm-vim-top-bottom-fixed](https://github.com/user-attachments/assets/b1f33b91-3272-485c-9f38-0a9233e237fd)

![llm-vim-bottom-top-fixed](https://github.com/user-attachments/assets/6c289233-d001-42bc-b708-0ad9bdc57d56)
