### PR TITLE
Fix some small issues in buffers.lua and files.lua and add check for an "error" reply to ollama.lua

### DIFF
--- a/lua/llm/backends/ollama.lua
+++ b/lua/llm/backends/ollama.lua
@@ -19,6 +19,11 @@ function ollama.StreamingHandler(chunk, ctx)
       return ctx.assistant_output
     end
 
+    if data.error then
+       F.WriteContent(ctx.bufnr, ctx.winid, "Error: " .. data.error)
+       return ctx.assistant_output
+    end
+
     if not data.message.content then
       ctx.finish_reason = data.done_reason
       return ctx.assistant_output

--- a/lua/llm/common/buffers.lua
+++ b/lua/llm/common/buffers.lua
@@ -1,12 +1,12 @@
+local state = require("llm.state")
+local F = require("llm.common.api")
+
 local buffers = {
   {
     label = "buffer",
     detail = "Quote the content of the buffer",
     kind_name = "llm.buffer",
     callback = function(bufnr, opts, co)
-      local state = require("llm.state")
-      local F = require("llm.common.api")
-
       local ft = vim.api.nvim_get_option_value("filetype", { buf = bufnr })
       local buffer_ctx_tbl, start_line, start_col, end_line, end_col =
         F.GetVisualSelectionRange(bufnr)
@@ -102,7 +102,7 @@ local buffers = {
         snacks.picker.buffers({
           actions = {
             close = function()
-              vim.api.startinsert()
+              vim.cmd.startinsert()
             end,
             confirm = function(picker, selected)
               picker:close()

--- a/lua/llm/common/files.lua
+++ b/lua/llm/common/files.lua
@@ -96,7 +96,7 @@ local files = {
         snacks.picker.files({
           actions = {
             close = function()
-              vim.api.startinsert()
+              vim.cmd.startinsert()
             end,
             confirm = function(picker, selected)
               picker:close()


### PR DESCRIPTION
In buffers.lua, the local variables "state" and "F" are used in both the "callback" function and the the "picker" function, but were defined only within "callback". Moved them to file scope, so they are available to both.

Additionally, in both buffers.lua and files.lua, changed call to "vim.api.startinsert()" to "vim.cmd.startinsert()" to be compatible with Neovim 0.11+

Added a check in ollama.lua for the case when Ollama replies with an "error" field and write that error to the message box. Otherwise, the user will simply see no reply.